### PR TITLE
fixing conflict session_start()

### DIFF
--- a/src/rcastera/Browser/Session/Session.php
+++ b/src/rcastera/Browser/Session/Session.php
@@ -29,7 +29,9 @@ class Session
      */
     public function __construct()
     {
-        session_start();
+        if(!$this->isRegistered()){
+            session_start();
+        }
     }
 
     /**


### PR DESCRIPTION
fixing $var = new Session(); which making session_start() everytime its initiated.